### PR TITLE
[Makefile] use current shell for "echo" in ubuntu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ FIGS := $(patsubst %.svg,%.pdf,$(wildcard fig/*.svg))
 PLOT := $(patsubst %.gp,%.tex,$(wildcard data/*.gp))
 DEPS := rev.tex code/fmt.tex abstract.txt $(CODE) $(FIGS) $(PLOT)
 BTEX := --bibtex-args="-min-crossrefs=99"
+SHELL:= $(shell echo $$SHELL)
 
 all: $(DEPS)
 	@TEXINPUTS="sty:" bin/latexrun $(BTEX) $(MAIN)


### PR DESCRIPTION
Hi,
This repository is very useful for me.

I use Ubuntu and found a minor bug, so i fixed it by this PR.

In Ubuntu, `make watermark` and `make draft` occur the following error.

``` bash
hoge@fuga:/tmp/die$ make draft 
echo -e '\\newcommand*{\\DRAFT}{}' >> rev.tex
/usr/share/texlive/texmf-dist/tex/latex/caption/caption.sty: warning: [caption] Unsupported document class (or package) detected, usage of the caption package is not recommended
rev.tex:3: error: Missing \begin{document}
      at -e \newcommand*{\DRAFT}{}
          ^
```

Makefile seems to use `/bin/sh` as default shell,
- https://www.gnu.org/software/make/manual/html_node/Choosing-the-Shell.html
- http://stackoverflow.com/questions/589276/how-can-i-use-bash-syntax-in-makefile-targets

and `/bin/sh` of Ubuntu doesn't recognize the `-e` option.

So, `echo -e '\\newcommand*{\\DRAFT}{}' >> rev.tex` results 

``` tex
\gdef\therev{04dd103}
\gdef\thedate{2015-05-09 11:00:49 -0400}
-e \newcommand*{\DRAFT}{}
```

By setting `SHELL := $(shell echo $$SHELL)` at the top of Makefile, we can use `/bin/bash` which recognizes `-e` option  in Ubuntu.
- http://stackoverflow.com/questions/14150003/echo-e-option-in-ubuntu-doesnt-work
