### PR TITLE
Only fix "make draft" and "make watermark"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,11 +50,11 @@ data/%.pdf: data/%.py ## generate plot
 
 draft: $(DEPS) ## generate pdf with a draft info
 	echo -e '\\newcommand*{\\DRAFT}{}' >> rev.tex
-	@TEXINPUTS="sty:" bin/latexrun $(BTEX) $(MAIN)
+	@TEXINPUTS="sty:" bin/latexrun $(LTEX) $(BTEX) $(MAIN)
 
 watermark: $(DEPS) ## generate pdf with a watermark
 	echo -e '\\usepackage[firstpage]{draftwatermark}' >> rev.tex
-	@TEXINPUTS="sty:" bin/latexrun $(BTEX) $(MAIN)
+	@TEXINPUTS="sty:" bin/latexrun $(LTEX) $(BTEX) $(MAIN)
 
 spell: ## run a spell check
 	@for i in *.tex fig/*.tex; do bin/aspell.sh tex $$i; done


### PR DESCRIPTION
This is a copy of PR #5 by @huhong789, but only the first commit (0592ad5) and not the second (e33756b).

0592ad5 fixes the `make draft` and `make watermark` commands. On my machine, e33756b [just creates new errors](https://github.com/tsgates/die/pull/5#issuecomment-1366964984), and it seems unrelated to the other commit as far as I can tell.