### PR TITLE
Work around minted incompatibility with latexrun

### DIFF
--- a/pkgs.tex
+++ b/pkgs.tex
@@ -24,7 +24,8 @@
 \usepackage{siunitx}
 
 % pseudo code
-\usepackage{minted}
+% https://github.com/aclements/latexrun/issues/13#issuecomment-322550767
+\usepackage[outputdir=latex.out]{minted}
 
 % balance bibliography
 \usepackage{balance}


### PR DESCRIPTION
minted has compatibility issues with latexrun, which this repo uses. I'm not sure why this hasn't affected other users of this repo yet, but [it's not just a problem on my end](https://github.com/aclements/latexrun/issues/13).

This PR adds a one-line workaround [taken from here](https://github.com/aclements/latexrun/issues/13#issuecomment-322550767).